### PR TITLE
fix: TOML correction key recursive escaping

### DIFF
--- a/menubar-app/Sources/ConfigManager.swift
+++ b/menubar-app/Sources/ConfigManager.swift
@@ -112,7 +112,7 @@ class ConfigManager: ObservableObject {
             let value = unquote(raw)
 
             if currentSection == "corrections" {
-                loadedCorrections[key] = value
+                loadedCorrections[unquote(key)] = value
                 continue
             }
 
@@ -251,8 +251,11 @@ class ConfigManager: ObservableObject {
         return v
     }
 
+    /// Escape a string value for TOML (inside double quotes).
+    /// Only backslashes and literal double-quotes inside the value need escaping.
     private func escape(_ s: String) -> String {
         s.replacingOccurrences(of: "\\", with: "\\\\")
          .replacingOccurrences(of: "\"", with: "\\\"")
     }
+
 }


### PR DESCRIPTION
## Summary

Correction keys were not unquoted on load, causing progressive escape nesting on each save cycle. After 2-3 corrections, the config.toml became unparseable.

## Fix

Apply `unquote()` to correction keys during load, same as values.