### PR TITLE
feat: add Parakeet TDT v3 as fourth STT engine

### DIFF
--- a/menubar-app/Sources/ConfigManager.swift
+++ b/menubar-app/Sources/ConfigManager.swift
@@ -17,6 +17,7 @@ class ConfigManager: ObservableObject {
     @Published var engine: String = "moonshine"
     @Published var whisperModel: String = "medium"
     @Published var moonshineModel: String = "moonshine/base"
+    @Published var parakeetModel: String = "tdt-0.6b-v3"
 
     static var configDir: URL {
         if let override = ProcessInfo.processInfo.environment["LOCAL_STT_CONFIG_DIR"]
@@ -78,6 +79,7 @@ class ConfigManager: ObservableObject {
         switch engine {
         case "mlx": return "mlx (\(whisperModel))"
         case "whisper": return "whisper (\(whisperModel))"
+        case "parakeet": return "parakeet (\(parakeetModel))"
         default: return "moonshine (\(moonshineModel))"
         }
     }
@@ -122,6 +124,7 @@ class ConfigManager: ObservableObject {
             case "engine": engine = value
             case "whisper_model": whisperModel = value
             case "moonshine_model": moonshineModel = value
+            case "parakeet_model": parakeetModel = value
             case "language": language = value
             case "initial_prompt": initialPrompt = value
             case "sound_effects": soundEffects = (value == "true")
@@ -137,7 +140,7 @@ class ConfigManager: ObservableObject {
 
     // MARK: - Validation
 
-    private static let validEngines = ["mlx", "whisper", "moonshine"]
+    private static let validEngines = ["mlx", "whisper", "moonshine", "parakeet"]
     private static let validModes = ["push-to-talk", "toggle"]
     private static let maxInitialPromptLength = 1000
 
@@ -201,6 +204,7 @@ class ConfigManager: ObservableObject {
         lines.append("engine = \"\(engine)\"")
         lines.append("moonshine_model = \"\(escape(moonshineModel))\"")
         lines.append("whisper_model = \"\(escape(whisperModel))\"")
+        lines.append("parakeet_model = \"\(escape(parakeetModel))\"")
         lines.append("sample_rate = 16000")
         lines.append("max_recording_seconds = 300")
         lines.append("output_mode = \"\(escape(outputMode))\"")

--- a/menubar-app/Sources/SettingsView.swift
+++ b/menubar-app/Sources/SettingsView.swift
@@ -120,6 +120,7 @@ private struct GeneralTab: View {
                     LabeledContent("Engine") {
                         Picker("", selection: $config.engine) {
                             Text("MLX Whisper").tag("mlx")
+                            Text("Parakeet TDT").tag("parakeet")
                             Text("Whisper").tag("whisper")
                             Text("Moonshine").tag("moonshine")
                         }
@@ -135,13 +136,14 @@ private struct GeneralTab: View {
 
                 VStack(alignment: .leading, spacing: 4) {
                     LabeledContent("Model") {
-                        Picker("", selection: config.engine == "moonshine"
-                            ? $config.moonshineModel
-                            : $config.whisperModel
-                        ) {
+                        Picker("", selection: modelBinding) {
                             if config.engine == "moonshine" {
                                 Text("Tiny").tag("moonshine/tiny")
                                 Text("Base").tag("moonshine/base")
+                            } else if config.engine == "parakeet" {
+                                Text("TDT 0.6B v3").tag("tdt-0.6b-v3")
+                                Text("TDT 0.6B v2").tag("tdt-0.6b-v2")
+                                Text("TDT 1.1B").tag("tdt-1.1b")
                             } else {
                                 Text("Tiny").tag("tiny")
                                 Text("Base").tag("base")
@@ -201,6 +203,14 @@ private struct GeneralTab: View {
             }
         }
         return machine?.contains("arm64") == true
+    }
+
+    private var modelBinding: Binding<String> {
+        switch config.engine {
+        case "moonshine": return $config.moonshineModel
+        case "parakeet": return $config.parakeetModel
+        default: return $config.whisperModel
+        }
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 whisper = ["faster-whisper>=1.0"]
+parakeet = ["parakeet-mlx>=0.5"]
 macos = ["pyobjc-framework-Cocoa"]
 menubar = ["rumps>=0.4"]
 windows = ["pywin32"]

--- a/src/claude_stt/config.py
+++ b/src/claude_stt/config.py
@@ -33,9 +33,10 @@ class Config:
     mode: Literal["push-to-talk", "toggle"] = "toggle"
 
     # Engine settings
-    engine: Literal["moonshine", "whisper"] = "moonshine"
+    engine: Literal["moonshine", "whisper", "mlx", "parakeet"] = "moonshine"
     moonshine_model: str = "moonshine/base"
     whisper_model: str = "medium"
+    parakeet_model: str = "tdt-0.6b-v3"
 
     # Audio settings
     sample_rate: int = 16000
@@ -128,6 +129,7 @@ class Config:
                 engine=stt_config.get("engine", cls.engine),
                 moonshine_model=stt_config.get("moonshine_model", cls.moonshine_model),
                 whisper_model=stt_config.get("whisper_model", cls.whisper_model),
+                parakeet_model=stt_config.get("parakeet_model", cls.parakeet_model),
                 sample_rate=stt_config.get("sample_rate", cls.sample_rate),
                 max_recording_seconds=stt_config.get(
                     "max_recording_seconds", cls.max_recording_seconds
@@ -172,6 +174,7 @@ class Config:
             "engine": self.engine,
             "moonshine_model": self.moonshine_model,
             "whisper_model": self.whisper_model,
+            "parakeet_model": self.parakeet_model,
             "sample_rate": self.sample_rate,
             "max_recording_seconds": self.max_recording_seconds,
             "min_recording_seconds": self.min_recording_seconds,
@@ -235,9 +238,13 @@ class Config:
             logger.warning("Invalid mode '%s'; defaulting to 'toggle'", self.mode)
             self.mode = "toggle"
 
-        if self.engine not in ("moonshine", "whisper", "mlx"):
+        if self.engine not in ("moonshine", "whisper", "mlx", "parakeet"):
             logger.warning("Invalid engine '%s'; defaulting to 'moonshine'", self.engine)
             self.engine = "moonshine"
+
+        if not isinstance(self.parakeet_model, str) or not self.parakeet_model.strip():
+            logger.warning("Invalid parakeet_model; defaulting to 'tdt-0.6b-v3'")
+            self.parakeet_model = "tdt-0.6b-v3"
 
         if not isinstance(self.moonshine_model, str) or not self.moonshine_model.strip():
             logger.warning("Invalid moonshine_model; defaulting to 'moonshine/base'")

--- a/src/claude_stt/daemon_service.py
+++ b/src/claude_stt/daemon_service.py
@@ -357,7 +357,14 @@ class STTDaemon:
                 self._logger.warning("Dropping transcription; queue is full")
                 self._overlay_send("CANCEL")
         else:
-            # No audio captured — cancel the transcribing indicator
+            # No audio captured — common cause: wrong default input device,
+            # disconnected mic, or PaMacCore stream error. Logged so the
+            # user can spot input-routing issues without UI silence.
+            self._logger.warning(
+                "No audio captured from recorder (recording was %.1fs); "
+                "check default input device",
+                self._last_duration_s,
+            )
             self._overlay_send("CANCEL")
             if self.config.sound_effects:
                 play_sound("warning")

--- a/src/claude_stt/engine_factory.py
+++ b/src/claude_stt/engine_factory.py
@@ -4,6 +4,7 @@ from .config import Config
 from .engines import STTEngine
 from .engines.mlx_engine import MLXWhisperEngine
 from .engines.moonshine import MoonshineEngine
+from .engines.parakeet_engine import ParakeetEngine
 from .engines.whisper import WhisperEngine
 from .errors import EngineError
 
@@ -24,4 +25,6 @@ def build_engine(config: Config) -> STTEngine:
             language=config.language,
             initial_prompt=config.initial_prompt,
         )
+    if config.engine == "parakeet":
+        return ParakeetEngine(model_name=config.parakeet_model)
     raise EngineError(f"Unknown engine '{config.engine}'")

--- a/src/claude_stt/engines/parakeet_engine.py
+++ b/src/claude_stt/engines/parakeet_engine.py
@@ -1,0 +1,115 @@
+"""Parakeet TDT STT engine for Apple Silicon (NVIDIA Parakeet via MLX)."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+_parakeet_available = False
+
+try:
+    import mlx.core as mx
+    from parakeet_mlx import from_pretrained
+    from parakeet_mlx.audio import get_logmel
+
+    _parakeet_available = True
+except ImportError:
+    mx = None  # type: ignore[assignment]
+    from_pretrained = None  # type: ignore[assignment]
+    get_logmel = None  # type: ignore[assignment]
+
+
+# Map short names to HuggingFace MLX-community model repos.
+_MODEL_MAP = {
+    "tdt-0.6b-v3": "mlx-community/parakeet-tdt-0.6b-v3",
+    "tdt-0.6b-v2": "mlx-community/parakeet-tdt-0.6b-v2",
+    "tdt-1.1b": "mlx-community/parakeet-tdt-1.1b",
+}
+
+
+class ParakeetEngine:
+    """NVIDIA Parakeet TDT engine using MLX on Apple Silicon.
+
+    Parakeet is multilingual (25 European languages including German) and
+    typically delivers sub-100ms latency. Unlike Whisper it does not accept
+    a language hint or initial prompt; the model auto-detects from audio.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "tdt-0.6b-v3",
+    ):
+        self.model_name = model_name
+        self._hf_repo = _MODEL_MAP.get(model_name, model_name)
+        self._model = None
+        self._logger = logging.getLogger(__name__)
+
+    def is_available(self) -> bool:
+        return _parakeet_available
+
+    def load_model(self) -> bool:
+        if not self.is_available():
+            return False
+        if self._model is not None:
+            return True
+        try:
+            self._logger.info("Loading Parakeet model: %s", self._hf_repo)
+            self._model = from_pretrained(self._hf_repo)
+            # Force eager weight load so the first transcribe() call is
+            # responsive instead of blocking 30+s on lazy materialization.
+            import numpy as _np
+
+            warmup = mx.array(_np.zeros(16000, dtype=_np.float32))
+            mel = get_logmel(warmup, self._model.preprocessor_config)
+            self._model.generate(mel)
+            self._logger.info("Parakeet model ready")
+            return True
+        except Exception:
+            self._logger.exception("Failed to load Parakeet model")
+            return False
+
+    def transcribe(self, audio: np.ndarray, sample_rate: int = 16000) -> str:
+        if not self.load_model():
+            return ""
+        try:
+            if audio.dtype != np.float32:
+                audio = audio.astype(np.float32)
+
+            expected_sr = self._model.preprocessor_config.sample_rate
+            if sample_rate != expected_sr:
+                self._logger.warning(
+                    "Sample rate mismatch (got %d, model expects %d); "
+                    "transcription quality may degrade",
+                    sample_rate,
+                    expected_sr,
+                )
+
+            audio_mx = mx.array(audio)
+            mel = get_logmel(audio_mx, self._model.preprocessor_config)
+            results = self._model.generate(mel)
+            if not results:
+                return ""
+            text = results[0].text.strip()
+
+            if self._has_excessive_repetition(text):
+                self._logger.warning(
+                    "Repetitive output detected, discarding transcription"
+                )
+                return ""
+
+            return text
+        except Exception:
+            self._logger.exception("Parakeet transcription failed")
+            return ""
+
+    @staticmethod
+    def _has_excessive_repetition(text: str, threshold: int = 5) -> bool:
+        """Return True if more than `threshold` consecutive identical words."""
+        words = text.split()
+        if len(words) < threshold:
+            return False
+        for i in range(len(words) - threshold + 1):
+            if len(set(words[i : i + threshold])) == 1:
+                return True
+        return False

--- a/tests/test_engine_factory.py
+++ b/tests/test_engine_factory.py
@@ -2,6 +2,7 @@ import unittest
 
 from claude_stt.config import Config
 from claude_stt.engine_factory import build_engine
+from claude_stt.engines.parakeet_engine import ParakeetEngine
 from claude_stt.engines.whisper import WhisperEngine
 from claude_stt.errors import EngineError
 
@@ -18,6 +19,12 @@ class EngineFactoryTests(unittest.TestCase):
         config = Config(engine="whisper")
         engine = build_engine(config)
         self.assertIsInstance(engine, WhisperEngine)
+
+    def test_parakeet_engine_constructed(self):
+        config = Config(engine="parakeet")
+        engine = build_engine(config)
+        self.assertIsInstance(engine, ParakeetEngine)
+        self.assertEqual(engine.model_name, "tdt-0.6b-v3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #21

## Summary

Adds NVIDIA Parakeet TDT v3 (via parakeet-mlx) as a selectable on-device STT engine alongside Moonshine, Whisper, and MLX Whisper. All four engines now exposed in the SwiftUI Settings dropdown with their own model selectors.

## Verification

- 9 unit tests green
- 9.24s German audio: load_model 1.02s (cache hit), first transcribe 1.35s, warm transcribe 0.09s
- End-to-end daemon test confirmed working

## Notes

- Engine eagerly warms up weights after from_pretrained() to avoid first-call blocking
- Diagnostic warning added when recorder returns empty audio (helps spot input-routing issues)
- parakeet-mlx is an optional dep: `pip install ".[parakeet]"`
- Parakeet does not accept language= or initial_prompt= (auto-detect)