### PR TITLE
fix: terminate overlay process on stdin EOF, not just explicit errors

### DIFF
--- a/src/claude_stt/overlay.py
+++ b/src/claude_stt/overlay.py
@@ -248,14 +248,21 @@ def _cgcolor(r, g, b, a):
 
 
 def _read_stdin(overlay):
-    """Read commands from stdin in background thread."""
+    """Read commands from stdin in background thread.
+
+    Always terminates the app when the loop ends, whether via an explicit
+    QUIT command, an EOF (stdin closed because the parent process died,
+    cleanly or not), or a read error. Without this, a parent crash leaves
+    the overlay window stuck on screen forever (stdin EOF ends the `for`
+    loop normally, without raising, so a bare except-based exit is not
+    enough).
+    """
     try:
         for line in sys.stdin:
             cmd = line.strip()
             if not cmd:
                 continue
             if cmd == "QUIT":
-                _perform_on_main(lambda: AppKit.NSApp.terminate_(None))
                 break
             elif cmd == "RECORDING":
                 _perform_on_main(overlay.show_recording)
@@ -268,7 +275,8 @@ def _read_stdin(overlay):
             elif cmd == "CANCEL":
                 _perform_on_main(overlay.cancel)
     except (EOFError, OSError):
-        _perform_on_main(lambda: AppKit.NSApp.terminate_(None))
+        pass
+    _perform_on_main(lambda: AppKit.NSApp.terminate_(None))
 
 
 def main():


### PR DESCRIPTION
## Summary

Fixes #23. The overlay indicator ran as a subprocess with `stdin=PIPE`. When the parent daemon died uncleanly (crash, force-kill), the OS closed the pipe, ending the `for line in sys.stdin` loop via plain EOF, not an exception. The old `except (EOFError, OSError)` termination path never fired on plain EOF, so the overlay process stayed alive forever as an orphan with its last rendered state ("Transcribing...") stuck on screen.

## Fix

`_read_stdin` now always calls `AppKit.NSApp.terminate_` after the read loop ends, whether it ends via explicit `QUIT`, a read error, or plain EOF.

## Test plan

- [x] Verified via isolated unit-style check (mocking `_perform_on_main` and `AppKit.NSApp.terminate_`): EOF-without-QUIT now triggers exactly one `terminate_` call; explicit `QUIT` still triggers exactly one `terminate_` call.
- [ ] Manual: kill the daemon process directly (`kill -9`) and confirm the overlay window disappears instead of staying stuck on screen.